### PR TITLE
Use tldextract to determine the domain

### DIFF
--- a/modoboa_dmarc/views.py
+++ b/modoboa_dmarc/views.py
@@ -2,6 +2,7 @@
 
 import collections
 import datetime
+import tldextract
 
 from dns import resolver, reversename
 
@@ -24,10 +25,8 @@ def insert_record(target, record):
         addr = reversename.from_address(record.source_ip)
         try:
             resp = resolver.query(addr, "PTR")
-            node = resp[0].target
-            while len(node.labels) > 3:
-                node = node.parent()
-            name = node
+            ext = tldextract.extract(str(resp[0].target))
+            name = '.'.join((ext.domain, ext.suffix))
         except (resolver.NXDOMAIN, resolver.NoNameservers, resolver.Timeout):
             pass
 

--- a/modoboa_dmarc/views.py
+++ b/modoboa_dmarc/views.py
@@ -26,7 +26,7 @@ def insert_record(target, record):
         try:
             resp = resolver.query(addr, "PTR")
             ext = tldextract.extract(str(resp[0].target))
-            name = '.'.join((ext.domain, ext.suffix))
+            name = '.'.join((ext.domain, ext.suffix)).lower()
         except (resolver.NXDOMAIN, resolver.NoNameservers, resolver.Timeout):
             pass
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 modoboa>=1.7.0
+tldextract>=2.0.2


### PR DESCRIPTION
The naive approach to resolving the domain neglects that some domain names consist of more than two DNS labels (e.g. foobar.co.uk). Since this completely depends on the registrar for a given TLD, there is no algorithmic solution. Instead, browser manufacturers have created the [Public Suffix List](https://www.publicsuffix.org) to accurately determine domain names. 

This PR uses the `tldextract` package to manage access to the Public Suffix List and display the true domain name for the processed DMARC reports.