### PR TITLE
Use asynchronous DNS lookups

### DIFF
--- a/modoboa_dmarc/views.py
+++ b/modoboa_dmarc/views.py
@@ -109,6 +109,8 @@ class DomainReportView(
                 try:
                     resp = dns_resolver.query(addr, "PTR")
                     ext = tldextract.extract(str(resp[0].target))
+                    if not ext.suffix:  # invalid PTR record
+                        raise resolver.NXDOMAIN()
                     return (ip, '.'.join((ext.domain, ext.suffix)).lower())
                 except (resolver.NXDOMAIN, resolver.YXDOMAIN, resolver.NoAnswer,
                         resolver.NoNameservers, resolver.Timeout):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 modoboa>=1.7.0
 tldextract>=2.0.2
+futures>=3.1.0


### PR DESCRIPTION
Use asynchronous DNS lookups to speed up the domain name discovery process.