### PR TITLE
32 no traceback on failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ addons:
   mysql: '5.5'
 
 before_install:
+  - pip install --upgrade pip
   - pip install codecov
   - pip install -e git+https://github.com/modoboa/modoboa.git#egg=modoboa
 

--- a/modoboa_dmarc/lib.py
+++ b/modoboa_dmarc/lib.py
@@ -147,7 +147,7 @@ def import_report_from_email(content):
         try:
             fpo = six.BytesIO(part.get_payload(decode=True))
             import_archive(fpo, content_type=part.get_content_type())
-        except OSError:
+        except (OSError, IOError):
             print('Error: the attachment does not match the mimetype')
             err = True
         else:

--- a/modoboa_dmarc/tests/fail-reports/Report_Domain_ngyn.org_Submitter_163.com_Report-ID_aggr_report_ngyn.org_20150705_163-failed.com.eml
+++ b/modoboa_dmarc/tests/fail-reports/Report_Domain_ngyn.org_Submitter_163.com_Report-ID_aggr_report_ngyn.org_20150705_163-failed.com.eml
@@ -1,0 +1,67 @@
+Return-Path: <abuse@163.com>
+Delivered-To: <tonio@ngyn.org>
+Received: from mail.koalabs.org
+	by nelson.ngyn.org (Dovecot) with LMTP id IKPdD1ULmlXgLQAABvoInA
+	for <tonio@ngyn.org>; Mon, 06 Jul 2015 07:00:05 +0200
+Received: from localhost (localhost.localdomain [127.0.0.1])
+	by mail.koalabs.org (Postfix) with ESMTP id 2645EE035B
+	for <postmaster@ngyn.org>; Mon,  6 Jul 2015 07:00:05 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at mail.koalabs.org
+Received: from mail.koalabs.org ([127.0.0.1])
+	by localhost (nelson.ngyn.org [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP for <postmaster@ngyn.org>;
+	Mon,  6 Jul 2015 07:00:03 +0200 (CEST)
+Received: from m12-181.163.com (m12-181.163.com [220.181.12.181])
+	by mail.koalabs.org (Postfix) with ESMTP
+	for <postmaster@ngyn.org>; Mon,  6 Jul 2015 06:59:54 +0200 (CEST)
+Received: from 163.com (unknown [192.168.201.141])
+	by mfast1 (Coremail) with SMTP id tcCowEAJixEvC5pVHJvvLg--.53754S2;
+	Mon, 06 Jul 2015 12:59:27 +0800 (CST)
+Content-Type: multipart/mixed; boundary="===============2544031943362770105=="
+MIME-Version: 1.0
+From: <abuse@163.com>
+Date: Mon, 06 Jul 2015 12:59:25 +0800
+Subject: Report Domain: ngyn.org Submitter: 163.com Report-ID:
+ aggr_report_ngyn.org_20150705_163.com
+To: postmaster@ngyn.org
+X-CM-TRANSID:tcCowEAJixEvC5pVHJvvLg--.53754S2
+Message-Id:<559A0B30.EBEE1F.29746@m12-181.163.com>
+X-Coremail-Antispam: 1UD129KBjDUn29KB7ZKAUJUUUUU529EdanIXcx71UUUUU7v73
+	VFW2AGmfu7bjvjm3AaLaJ3UjIYCTnIWjp_UUUnI7CY07I20VC2zVCF04k26cxKx2IYs7xG
+	6rWj6s0DM28lY4IEw2IIxxk0rwA2F7IY1VAKz4vEj48ve4kI8wAa7VASzI0EjI02j7AqF2
+	xKxVCjxxvEa2IrM2AIxVAIcxkEcVAq07x20xvEncxIr21le4C267I2x7xF54xIwI1l5I8C
+	rVACY4xI64kE6c02F40Ex7xfMcIj6x8ErcxFaVAv8VWrMcvjeVCFs4IE7xkEbVWUJVW8Jw
+	ACjcxG0xvEwIxGrwAKzVAC0xCFj2AI6cx7M4kE6xkIj40Ew7xC0wCjxxvEa2IrMxkIecxE
+	wVCm-wCY0x0Ix7I2Y4AK64vIr41l42xK82IYc2Ij64vIr41l42xK82IY6x8ErcxFaVAv8V
+	WrMxCjnVAqn7xvrwCFx2IqxVCFs4IE7xkEbVWUJVW8JwC20s026c02F40E14v26r1j6r18
+	MI8I3I0E7480Y4vE14v26r106r1rMI8E67AF67kF1VAFwI0_Jr0_JrylIxkGc2Ij64vIr4
+	1l6VACY4xI67k04243AbIYCTnIWIevJa73UjIFyTuYvjTRClkVDUUUU
+X-Originating-IP: [192.168.201.141]
+X-CM-SenderInfo: 5dex2vi6rwjhhfrp/
+
+--===============2544031943362770105==
+Content-Type: text/plain; charset="us-ascii"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+
+This is a DMARC aggregate report for domain ngyn.org on 20150705. For more information please mail to abuse@163.com.
+--===============2544031943362770105==
+MIME-Version: 1.0
+Content-Type: application/gzip;
+ name="163.com!ngyn.org!1436054400!1436140799.zip"
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment;
+ filename="163.com!ngyn.org!1436054400!1436140799.zip"
+
+UEsDBBQAAAAIAGxn5kZGEGLBdAEAAJQDAAAqAAAAMTYzLmNvbSFuZ3luLm9yZyExNDM2MDU0NDAw
+ITE0MzYxNDA3OTkueG1sbVNbbsMgEPzvKXICg5M4USSEehOEzdpBsQEBbpXbF4eHadovzOzs7Owu
+JiOA6PnwoB+HA7FgtPVsAc8F93zDAqrtxBRfgLaXUzPohaCCRAIsXM6U96uDz8KJYCQkXSkonybL
+0lVNT9VsUkfcdviKO1aS94QoENwAs1xNqWSAepikou35dMHd+YwxQRHJcVDiFW3P+Hq7BT8qi6Hf
+aqVa3TYxepbDk5m1n6W7QzGiQ1uKZutBKwIxysVDLtQRFD8S6Mz4wrYzQoYqrYAgk+4uAy4jZvC0
+C4RwvCz+ZyeMddA2O7P6u/Tu9GoHYNLQtu2aIz42l3CcguAeydxBr8rTlqD4keFUEL74vIZxiRzY
+ZiCd0U56qVWyXSMVb5vBGF5BIJRxpH7HFCgzqZp8qxn2k1sjUoDycpRgXUm7Axdg2Wj1Qtdm30yN
+J6E/6YSv/h7eo1tnvytWpvaV19L10tMD3xTSNNKltLXvHb2X28hxhwSVP/EHUEsBAhQDFAAAAAgA
+bGfmRkYQYsF0AQAAlAMAACoAAAAAAAAAAAAAAKSBAAAAADE2My5jb20hbmd5bi5vcmchMTQzNjA1
+NDQwMCExNDM2MTQwNzk5LnhtbFBLBQYAAAAAAQABAFgAAAC8AQAAAAA=
+--===============2544031943362770105==--
+

--- a/modoboa_dmarc/tests/mixins.py
+++ b/modoboa_dmarc/tests/mixins.py
@@ -45,5 +45,5 @@ class CallCommandMixin(object):
             fpath = os.path.join(path, f)
             if f.startswith(".") or not os.path.isfile(fpath):
                 continue
-            ret = self.import_report(fpath)
-            self.assertNotIn('ERROR-PARSING', ret)
+            with self.assertRaisesMessage(SystemExit, '65'):
+                self.import_report(fpath)

--- a/modoboa_dmarc/tests/mixins.py
+++ b/modoboa_dmarc/tests/mixins.py
@@ -6,6 +6,7 @@ import sys
 import six
 
 from django.core.management import call_command
+from django.utils.six import StringIO
 
 
 class CallCommandMixin(object):
@@ -24,7 +25,9 @@ class CallCommandMixin(object):
         with open(path) as fp:
             buf = six.StringIO(fp.read())
         sys.stdin = buf
-        call_command("import_aggregated_report", "--pipe")
+        out = StringIO()
+        call_command("import_aggregated_report", "--pipe", stdout=out)
+        return out.getvalue()
 
     def import_reports(self, folder="reports"):
         """Import reports from folder."""
@@ -42,5 +45,5 @@ class CallCommandMixin(object):
             fpath = os.path.join(path, f)
             if f.startswith(".") or not os.path.isfile(fpath):
                 continue
-            self.import_report(fpath)
-            # TODO check return code different from 0
+            ret = self.import_report(fpath)
+            self.assertNotIn('ERROR-PARSING', ret)

--- a/modoboa_dmarc/tests/mixins.py
+++ b/modoboa_dmarc/tests/mixins.py
@@ -34,3 +34,13 @@ class CallCommandMixin(object):
             if f.startswith(".") or not os.path.isfile(fpath):
                 continue
             self.import_report(fpath)
+
+    def import_fail_reports(self, folder="fail-reports"):
+        """Import failed reports from folder."""
+        path = os.path.join(os.path.dirname(__file__), folder)
+        for f in os.listdir(path):
+            fpath = os.path.join(path, f)
+            if f.startswith(".") or not os.path.isfile(fpath):
+                continue
+            self.import_report(fpath)
+            # TODO check return code different from 0

--- a/modoboa_dmarc/tests/test_management_command.py
+++ b/modoboa_dmarc/tests/test_management_command.py
@@ -18,6 +18,7 @@ class ManagementCommandTestCase(mixins.CallCommandMixin, ModoTestCase):
     def test_import_from_archive(self):
         """Import report from archive."""
         self.import_reports()
+        self.import_fail_reports()
         self.assertTrue(self.domain.record_set.exists())
         self.assertTrue(
             models.Reporter.objects.filter(

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,12 @@ from __future__ import unicode_literals
 
 import io
 from os import path
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
+
+try: # for pip >= 10
+        from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+        from pip.req import parse_requirements
 
 
 def get_requirements(requirements_file):


### PR DESCRIPTION
If attachment is incorrect, don't send traceback and proper return code (like 65 )
see http://www.postfix.org/pipe.8.html and https://gist.github.com/bojanrajkovic/831993#file-sysexits-h-L101

ref #32 