### PR TITLE
Show ARC pass as forwarders in DMARC report

### DIFF
--- a/modoboa_dmarc/templates/modoboa_dmarc/domain_report.html
+++ b/modoboa_dmarc/templates/modoboa_dmarc/domain_report.html
@@ -20,11 +20,13 @@
                columns: [
                    ['{% trans "Fully aligned" %}', {{ pie_data.faligned|unlocalize }}],
                    ['{% trans "Partially aligned" %}', {{ pie_data.paligned|unlocalize }}],
+                   ['{% trans "Forwarded" %}', {{ pie_data.forwarded|unlocalize }}],
                    ['{% trans "Failed" %}', {{ pie_data.failed|unlocalize }}]
                ],
                colors: {
                    '{% trans "Fully aligned" %}': 'limegreen',
                    '{% trans "Partially aligned" %}': 'gold',
+                   '{% trans "Forwarded" %}': 'lightskyblue',
                    '{% trans "Failed" %}': 'lightcoral',
                },
                type : 'pie'
@@ -68,9 +70,9 @@
     <div class="col-sm-7">
       <div class="row">
         <div class="col-sm-6">
-          <div class="panel panel-info text-center">
+          <div class="panel panel-primary text-center">
             <div class="panel-body">
-              <h1 class="text-info">{{ stats.total }}</h1>
+              <h1 class="text-primary">{{ stats.total }}</h1>
               <h4>{% trans "processed" %}</h4>
             </div>
           </div>
@@ -88,8 +90,17 @@
         <div class="col-sm-6">
           <div class="panel panel-warning text-center">
             <div class="panel-body">
-              <h1 class="text-warning" >{{ stats.paligned }}</h1>
+              <h1 class="text-warning" >{{ stats.trusted }}</h1>
               <h4>{% trans "partially aligned" %}</h4>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-sm-6">
+          <div class="panel panel-info text-center">
+            <div class="panel-body">
+              <h1 class="text-info" >{{ stats.forwarded }}</h1>
+              <h4>{% trans "forwarded" %}</h4>
             </div>
           </div>
         </div>
@@ -112,10 +123,26 @@
   </div>
 
   <div id="report-details" style="display: none">
-    <h1><small>{% trans "Trusted sources" %} <span class="text-success">{{ stats.trusted }}</span></small></h1>
+    <h1><small>{% trans "Trusted sources" %} <span class="text-success">{{ stats.aligned }}</span></small></h1>
+
+    <table class="table">
+      {% for domain, stats in aligned|domain_sorted_items %}
+        {% include "modoboa_dmarc/_result_detail.html" with domain=domain stats=stats %}
+      {% endfor %}
+    </table>
+
+    <h1><small>{% trans "Partially trusted sources / Forwarders" %} <span class="text-warning">{{ stats.trusted }}</span></small></h1>
 
     <table class="table">
       {% for domain, stats in trusted|domain_sorted_items %}
+        {% include "modoboa_dmarc/_result_detail.html" with domain=domain stats=stats %}
+      {% endfor %}
+    </table>
+
+    <h1><small>{% trans "Forwarders with ARC" %} <span class="text-info">{{ stats.forwarded }}</span></small></h1>
+
+    <table class="table">
+      {% for domain, stats in forwarded|domain_sorted_items %}
         {% include "modoboa_dmarc/_result_detail.html" with domain=domain stats=stats %}
       {% endfor %}
     </table>

--- a/modoboa_dmarc/tests/reports/Report_Domain_ngyn.org_Submitter_google.com_Report-ID_1282989064754998675.eml
+++ b/modoboa_dmarc/tests/reports/Report_Domain_ngyn.org_Submitter_google.com_Report-ID_1282989064754998675.eml
@@ -1,0 +1,51 @@
+Return-Path: <noreply-dmarc-support@google.com>
+Delivered-To: <tonio@ngyn.org>
+Received: from mail.koalabs.org
+	by nelson.ngyn.org (Dovecot) with LMTP id dV+vEDEApVVCdQAABvoInA
+	for <tonio@ngyn.org>; Tue, 03 Jun 2021 14:27:34 +0200
+Received: from localhost (localhost.localdomain [127.0.0.1])
+	by mail.koalabs.org (Postfix) with ESMTP id C28EFE035E
+	for <dmarc-aggrep@ngyn.org>; Tue, 03 Jun 2021 14:27:34 +0200 (CEST)
+X-Virus-Scanned: Debian amavisd-new at mail.koalabs.org
+Received: from mail.koalabs.org ([127.0.0.1])
+	by localhost (nelson.ngyn.org [127.0.0.1]) (amavisd-new, port 10024)
+	with ESMTP for <dmarc-aggrep@ngyn.org>;
+	Tue, 03 Jun 2021 14:27:32 +0200 (CEST)
+Received: from mail-vn0-f74.google.com (mail-vn0-f74.google.com [209.85.216.74])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES128-GCM-SHA256 (128/128 bits))
+	(No client certificate requested)
+	by mail.koalabs.org (Postfix) with ESMTPS
+	for <dmarc-aggrep@ngyn.org>; Tue, 03 Jun 2021 14:27:29 +0200 (CEST)
+Received: by vnbf7 with SMTP id f7so392460vnb.1
+        for <dmarc-aggrep@ngyn.org>; Tue, 03 Jun 2021 05:27:28 -0700 (PDT)
+MIME-Version: 1.0
+X-Received: by 10.52.251.34 with SMTP id zh2mr50557742vdc.8.1436869893195;
+ Tue, 03 Jun 2021 03:31:33 -0700 (PDT)
+Message-ID: <14872432101891615947@google.com>
+Date: Tue, 03 Jun 2021 10:31:33 +0000
+Subject: Report domain: ngyn.org Submitter: google.com Report-ID: 1282989064754998675
+From: noreply-dmarc-support@google.com
+To: dmarc-aggrep@ngyn.org
+Content-Type: application/zip; 
+	name="google.com!ngyn.org!1622592000!1622678399.zip"
+Content-Disposition: attachment; 
+	filename="google.com!ngyn.org!1622592000!1622678399.zip"
+Content-Transfer-Encoding: base64
+
+UEsDBBQDAAAIAMhzw1IU0YnahAIAAAQMAAAtAAAAZ29vZ2xlLmNvbSFuZ3luLm9yZyExNjIyNTky
+MDAwITE2MjI2NzgzOTkueG1s7ZbBctsgFEX3+QqP9wYJ24rUIaSrfkG71hDpWWYiAQM4if++WAJJ
+ressmridTrOSuPCu3rs+w5jev3Tt4gmMFUreLVOULBcgK1UL2dwtv339ssqXi3t2Q3cA9QOvHtnN
+YkENaGVc2YHjNXf8pHlVmaaUvAPWKNW0gCrVURzFcAY6LlomlXdoj6u646Za2YM+2X2el/XnYs2L
+M7yslHS8cqWQO8X2zmn7CeNQiqZSzDGX9hkMJpss2+YJxef1wTiMIWqWkpwUeZFkm9vtpijy7HZL
+8bgdjvtRoTRcNmEYLz1AIyRLM0K2BUkS/7FBifsg6343u83XRUExyGiGf3Sj+BeZUq1aUR1LfXho
+hd3D2Ijy6Ugmm6NEPl+KByHs8vpRdMxS3L9E0epdr/lnkDSTSgLFOqxtFGxUdOWYz8E/hhbP2hlY
+qJSJnRn1PM5u1cFUUArNSFKgfIsISVDmQ5g24tFKHaRjhOL+JcpxfHji7YG7OP4QgbBaWeE8taHr
+uTKd6yPYeZYontII4+7CxhhJgILbYBEld9TAWlXxthxaoriX5mc8eh343j3Qd5pbH3VUJmscveP6
+fMBBH2OkovYWYifA2LFsD7wGU+6M6mYMzNRoc1ZM+cHtSwP20LrJbwpmThe88E63sPJjIJKk2yQj
+a9Rwra3tnEZejtzNagdrNgQQFrPIoYXKKcOiH8VRmjKJ3cQf6WJnr7YQoAiL0XyiH/8cBcU9yb8D
+9Sa9DPXmWlD3Gb8K9b/BWXR+C00kTdbr9G00SXB/kaa0IChBBKXJKyit/zhLp40Pli6w9F7ff2eQ
+crRNPUcJWl9GKb0WSafL5/+4lU4DXY+kcCtdDSaKpz/03wFQSwECPwMUAwAACADIc8NSFNGJ2oQC
+AAAEDAAALQAkAAAAAAAAACCAtIEAAAAAZ29vZ2xlLmNvbSFuZ3luLm9yZyExNjIyNTkyMDAwITE2
+MjI2NzgzOTkueG1sCgAgAAAAAAABABgAgCVxNHRY1wGAJXE0dFjXAQBf60Z0WNcBUEsFBgAAAAAB
+AAEAfwAAAM8CAAAAAA==
+

--- a/modoboa_dmarc/tests/test_views.py
+++ b/modoboa_dmarc/tests/test_views.py
@@ -64,3 +64,14 @@ class DMARCViewsTestCase(mixins.CallCommandMixin, ModoTestCase):
         response = self.client.get("{}?period=2018-52".format(url))
         self.assertContains(response, "Dec. 30, 2018")
 
+    def test_domainreport_view_arc(self):
+        """Test domain report view for displaying ARC results"""
+        self.import_reports()
+        user = core_models.User.objects.get(username="admin")
+        self.client.force_login(user)
+        url = reverse("modoboa_dmarc:domain_report", args=[self.domain.pk])
+        response = self.client.get("{}?period=2021-22".format(url))
+        self.assertContains(response, "'Fully aligned', 86.0")
+        self.assertContains(response, "'Partially aligned', 8.0")
+        self.assertContains(response, "'Forwarded', 4.0")
+        self.assertContains(response, "'Failed', 2.0")


### PR DESCRIPTION
This PR introduces a first support for ARC results inside the DMARC aggregate reports. This is done by checking for `reason_type` and `reason_comment` according to https://datatracker.ietf.org/doc/html/rfc8617#section-7.2.2.

Addidtionally it also separates fully aligned records from partially aligned records. Most of the time those partially aligned records will be forwarders, but it may also be an indiciation to some misconfigured (internal or second party) mailserver.

Here is a sample screenshot of a report containing fully aligned, partially aligned, forwarded and untrusted records: 
![grafik](https://user-images.githubusercontent.com/19712240/117857254-dbef7100-b28c-11eb-94b3-410cbd37ca13.png)

The tool https://us.dmarcian.com/dmarc-xml/ actually lists ARC authentificated results directly under forwarders and thus in the same category as partially aligned records. However, I would prefer to leave them separate.

Please tell me, it there are any further changes required.  Especially regarding the wording and color scheme, since I was not really sure about those.

Fixes #50 