### PR TITLE
Removed unnecessary requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 modoboa>=1.15.0
 tldextract>=2.0.2
-futures>=3.1.0
 defusedxml>=0.6.0
 python-magic>=0.4.24


### PR DESCRIPTION
This project does not need futures which is a Python 2 only library and this project only supports Python 3.

Fixes #60.