### PR TITLE
use email.message_from_bytes() for six.binary_type; fixes #44

### DIFF
--- a/modoboa_dmarc/lib.py
+++ b/modoboa_dmarc/lib.py
@@ -152,6 +152,8 @@ def import_report_from_email(content):
     """Import a report from an email."""
     if isinstance(content, six.string_types):
         msg = email.message_from_string(content)
+    elif isinstance(content, six.binary_type):
+        msg = email.message_from_bytes(content)
     else:
         msg = email.message_from_file(content)
     err = False


### PR DESCRIPTION
This is based on the patch that I put in a comment on #44. I add a code path to use email.message_from_bytes() as in my testing the script was getting binary literals back from imaplib.